### PR TITLE
Use getDrops() instead of quantityDropped() and getItemDropped()

### DIFF
--- a/src/main/java/com/rwtema/denseores/BlockDenseOre.java
+++ b/src/main/java/com/rwtema/denseores/BlockDenseOre.java
@@ -241,11 +241,16 @@ public class BlockDenseOre extends BlockOre {
 
             // get base drops 3 times
             for (int j = 0; j < 3; j++) {
-                int count = base.quantityDropped(m, fortune, world.rand);
-                for (int i = 0; i < count; i++) {
-                    Item item = base.getItemDropped(m, world.rand, fortune);
-                    if (item != null) {
-                        ret.add(new ItemStack(item, 1, base.damageDropped(m)));
+                ArrayList<ItemStack> drops = base.getDrops(world, x, y, z, m, fortune);
+                if (drops != null && !drops.isEmpty()) {
+                    ret.addAll(drops);
+                } else {
+                    int count = base.quantityDropped(m, fortune, world.rand);
+                    for (int i = 0; i < count; i++) {
+                        Item item = base.getItemDropped(m, world.rand, fortune);
+                        if (item != null) {
+                            ret.add(new ItemStack(item, 1, base.damageDropped(m)));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This fixes 2 Issues I stumbled across:
- dense forestry ores (apatite, tin and copper) always drop 3 apatite ore blocks (forestry 1.7.10-3.1.1.4)
- dense railcraft ores always drop 3 of their counterpart ore blocks instead of the items you would get without silk touch (Railcraft 1.7.10-9.3.3.0)

The issue with Railcraft is not that bad since it is giving me the correct ore blocks.
The issue with Forestry is worse because it gives the wrong ore type. (damageDropped(int) always returns 0)

This Screenshot shows what i get when breaking dense ores in version 1.4.2.
![denseores142](https://cloud.githubusercontent.com/assets/2636101/4651082/3275dd1a-5499-11e4-96a6-68dd70aea634.png)
#### Fix Forestry?

Should I open an Issue/PR on @ForestryMC to ask if they could fix it on their side? [(class forestry.core.gadgets.BlockResource)](https://github.com/ForestryMC/ForestryMC/blob/dev/src/main/java/forestry/core/gadgets/BlockResource.java)

``` JAVA
@Override
public int damageDropped(int metadata) {
    return metadata;
}
```

This simple function does fix the problem with always getting apatite ore blocks, but for apatite it would still give 3 ore blocks instead of 10-20 apatite shards. (because getItemDropped(...) returns the ore block like it does in railcraft).
