### PR TITLE
Create enhancedbiomes.cfg

### DIFF
--- a/example_configs/mods/enhancedbiomes.cfg
+++ b/example_configs/mods/enhancedbiomes.cfg
@@ -1,0 +1,918 @@
+# Example Config File
+# Make sure to replace the X's with consecutive numbers.
+# PLEASE NOTE: You must have the Dense EB Ores mod installed in order for these settings to have any effect (download link below).
+# Dense EB Ores: http://minecraft.curseforge.com/mc-mods/227909-dense-eb-ores
+
+ores {
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=0
+        S:baseBlockTexture=debo:coal_ore_0
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_basalt
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=1
+        S:baseBlockTexture=debo:coal_ore_1
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_shale
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=2
+        S:baseBlockTexture=debo:coal_ore_2
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_sandstone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=3
+        S:baseBlockTexture=debo:coal_ore_3
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_limestone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=4
+        S:baseBlockTexture=debo:coal_ore_4
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_slate
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=5
+        S:baseBlockTexture=debo:coal_ore_5
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_rhyolite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=6
+        S:baseBlockTexture=debo:coal_ore_6
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chalk
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=7
+        S:baseBlockTexture=debo:coal_ore_7
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_marble
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=8
+        S:baseBlockTexture=debo:coal_ore_8
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dolomite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=9
+        S:baseBlockTexture=debo:coal_ore_9
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_schist
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=10
+        S:baseBlockTexture=debo:coal_ore_10
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chert
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=11
+        S:baseBlockTexture=debo:coal_ore_11
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_gabbro
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreCoalEB
+        I:baseBlockMeta=12
+        S:baseBlockTexture=debo:coal_ore_12
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dacite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=0
+        S:baseBlockTexture=debo:diamond_ore_0
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_basalt
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=1
+        S:baseBlockTexture=debo:diamond_ore_1
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_shale
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=2
+        S:baseBlockTexture=debo:diamond_ore_2
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_sandstone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=3
+        S:baseBlockTexture=debo:diamond_ore_3
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_limestone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=4
+        S:baseBlockTexture=debo:diamond_ore_4
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_slate
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=5
+        S:baseBlockTexture=debo:diamond_ore_5
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_rhyolite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=6
+        S:baseBlockTexture=debo:diamond_ore_6
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chalk
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=7
+        S:baseBlockTexture=debo:diamond_ore_7
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_marble
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=8
+        S:baseBlockTexture=debo:diamond_ore_8
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dolomite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=9
+        S:baseBlockTexture=debo:diamond_ore_9
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_schist
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=10
+        S:baseBlockTexture=debo:diamond_ore_10
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chert
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=11
+        S:baseBlockTexture=debo:diamond_ore_11
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_gabbro
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreDiamondEB
+        I:baseBlockMeta=12
+        S:baseBlockTexture=debo:diamond_ore_12
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dacite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=0
+        S:baseBlockTexture=debo:emerald_ore_0
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_basalt
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=1
+        S:baseBlockTexture=debo:emerald_ore_1
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_shale
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=2
+        S:baseBlockTexture=debo:emerald_ore_2
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_sandstone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=3
+        S:baseBlockTexture=debo:emerald_ore_3
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_limestone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=4
+        S:baseBlockTexture=debo:emerald_ore_4
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_slate
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=5
+        S:baseBlockTexture=debo:emerald_ore_5
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_rhyolite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=6
+        S:baseBlockTexture=debo:emerald_ore_6
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chalk
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=7
+        S:baseBlockTexture=debo:emerald_ore_7
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_marble
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=8
+        S:baseBlockTexture=debo:emerald_ore_8
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dolomite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=9
+        S:baseBlockTexture=debo:emerald_ore_9
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_schist
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=10
+        S:baseBlockTexture=debo:emerald_ore_10
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chert
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=11
+        S:baseBlockTexture=debo:emerald_ore_11
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_gabbro
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreEmeraldEB
+        I:baseBlockMeta=12
+        S:baseBlockTexture=debo:emerald_ore_12
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dacite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=0
+        S:baseBlockTexture=debo:gold_ore_0
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_basalt
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=1
+        S:baseBlockTexture=debo:gold_ore_1
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_shale
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=2
+        S:baseBlockTexture=debo:gold_ore_2
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_sandstone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=3
+        S:baseBlockTexture=debo:gold_ore_3
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_limestone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=4
+        S:baseBlockTexture=debo:gold_ore_4
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_slate
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=5
+        S:baseBlockTexture=debo:gold_ore_5
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_rhyolite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=6
+        S:baseBlockTexture=debo:gold_ore_6
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chalk
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=7
+        S:baseBlockTexture=debo:gold_ore_7
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_marble
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=8
+        S:baseBlockTexture=debo:gold_ore_8
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dolomite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=9
+        S:baseBlockTexture=debo:gold_ore_9
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_schist
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=10
+        S:baseBlockTexture=debo:gold_ore_10
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chert
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=11
+        S:baseBlockTexture=debo:gold_ore_11
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_gabbro
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreGoldEB
+        I:baseBlockMeta=12
+        S:baseBlockTexture=debo:gold_ore_12
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dacite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=0
+        S:baseBlockTexture=debo:iron_ore_0
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_basalt
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=1
+        S:baseBlockTexture=debo:iron_ore_1
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_shale
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=2
+        S:baseBlockTexture=debo:iron_ore_2
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_sandstone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=3
+        S:baseBlockTexture=debo:iron_ore_3
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_limestone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=4
+        S:baseBlockTexture=debo:iron_ore_4
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_slate
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=5
+        S:baseBlockTexture=debo:iron_ore_5
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_rhyolite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=6
+        S:baseBlockTexture=debo:iron_ore_6
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chalk
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=7
+        S:baseBlockTexture=debo:iron_ore_7
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_marble
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=8
+        S:baseBlockTexture=debo:iron_ore_8
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dolomite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=9
+        S:baseBlockTexture=debo:iron_ore_9
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_schist
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=10
+        S:baseBlockTexture=debo:iron_ore_10
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chert
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=11
+        S:baseBlockTexture=debo:iron_ore_11
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_gabbro
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreIronEB
+        I:baseBlockMeta=12
+        S:baseBlockTexture=debo:iron_ore_12
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dacite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=0
+        S:baseBlockTexture=debo:lapis_ore_0
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_basalt
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=1
+        S:baseBlockTexture=debo:lapis_ore_1
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_shale
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=2
+        S:baseBlockTexture=debo:lapis_ore_2
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_sandstone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=3
+        S:baseBlockTexture=debo:lapis_ore_3
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_limestone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=4
+        S:baseBlockTexture=debo:lapis_ore_4
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_slate
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=5
+        S:baseBlockTexture=debo:lapis_ore_5
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_rhyolite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=6
+        S:baseBlockTexture=debo:lapis_ore_6
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chalk
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=7
+        S:baseBlockTexture=debo:lapis_ore_7
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_marble
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=8
+        S:baseBlockTexture=debo:lapis_ore_8
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dolomite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=9
+        S:baseBlockTexture=debo:lapis_ore_9
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_schist
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=10
+        S:baseBlockTexture=debo:lapis_ore_10
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chert
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=11
+        S:baseBlockTexture=debo:lapis_ore_11
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_gabbro
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreLapisEB
+        I:baseBlockMeta=12
+        S:baseBlockTexture=debo:lapis_ore_12
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dacite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=0
+        S:baseBlockTexture=debo:redstone_ore_0
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_basalt
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=1
+        S:baseBlockTexture=debo:redstone_ore_1
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_shale
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=2
+        S:baseBlockTexture=debo:redstone_ore_2
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_sandstone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=3
+        S:baseBlockTexture=debo:redstone_ore_3
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_limestone
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=4
+        S:baseBlockTexture=debo:redstone_ore_4
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_slate
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=5
+        S:baseBlockTexture=debo:redstone_ore_5
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_rhyolite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=6
+        S:baseBlockTexture=debo:redstone_ore_6
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chalk
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=7
+        S:baseBlockTexture=debo:redstone_ore_7
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_marble
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=8
+        S:baseBlockTexture=debo:redstone_ore_8
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dolomite
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=9
+        S:baseBlockTexture=debo:redstone_ore_9
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_schist
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=10
+        S:baseBlockTexture=debo:redstone_ore_10
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_chert
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=11
+        S:baseBlockTexture=debo:redstone_ore_11
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_gabbro
+    }
+
+    block_X {
+        S:baseBlock=enhancedbiomes:enhancedbiomes.tile.oreRedstoneEB
+        I:baseBlockMeta=12
+        S:baseBlockTexture=debo:redstone_ore_12
+        D:denseOreProbability=1
+        I:renderType=0
+        I:retroGenID=0
+        S:underlyingBlock=enhancedbiomes:stone_dacite
+    }
+	
+}


### PR DESCRIPTION
Created an example config to allow for the generation of dense Enhanced Biomes ores.

The 'Dense EB Ores' mod must also be installed in order for these settings to have any effect, which is also mentioned in the example config.