### PR TITLE
Update Railcraft.cfg

### DIFF
--- a/example_configs/mods/Railcraft.cfg
+++ b/example_configs/mods/Railcraft.cfg
@@ -3,7 +3,7 @@
 
 ores {
     block_X {
-        S:baseBlock=Railcraft:tile.railcraft.ore
+        S:baseBlock=Railcraft:ore
         I:baseBlockMeta=0
         S:baseBlockTexture=railcraft:ore.sulfur
         D:denseOreProbability=1
@@ -13,7 +13,7 @@ ores {
     }
 
     block_X {
-        S:baseBlock=Railcraft:tile.railcraft.ore
+        S:baseBlock=Railcraft:ore
         I:baseBlockMeta=1
         S:baseBlockTexture=railcraft:ore.saltpeter
         D:denseOreProbability=1
@@ -23,7 +23,7 @@ ores {
     }
 
     block_X {
-        S:baseBlock=Railcraft:tile.railcraft.ore
+        S:baseBlock=Railcraft:ore
         I:baseBlockMeta=2
         S:baseBlockTexture=railcraft:ore.dark.diamond
         D:denseOreProbability=1
@@ -33,7 +33,7 @@ ores {
     }
 
     block_X {
-        S:baseBlock=Railcraft:tile.railcraft.ore
+        S:baseBlock=Railcraft:ore
         I:baseBlockMeta=3
         S:baseBlockTexture=railcraft:ore.dark.emerald
         D:denseOreProbability=1
@@ -43,7 +43,7 @@ ores {
     }
 
     block_X {
-        S:baseBlock=Railcraft:tile.railcraft.ore
+        S:baseBlock=Railcraft:ore
         I:baseBlockMeta=4
         S:baseBlockTexture=railcraft:ore.dark.lapis
         D:denseOreProbability=1
@@ -53,7 +53,7 @@ ores {
     }
 
     block_X {
-        S:baseBlock=Railcraft:tile.railcraft.ore
+        S:baseBlock=Railcraft:ore
         I:baseBlockMeta=5
         S:baseBlockTexture=railcraft:ore.firestone
         D:denseOreProbability=1
@@ -63,7 +63,7 @@ ores {
     }
 
     block_X {
-        S:baseBlock=Railcraft:tile.railcraft.ore
+        S:baseBlock=Railcraft:ore
         I:baseBlockMeta=7
         S:baseBlockTexture=railcraft:ore.poor.iron
         D:denseOreProbability=1
@@ -73,7 +73,7 @@ ores {
     }
 
     block_X {
-        S:baseBlock=Railcraft:tile.railcraft.ore
+        S:baseBlock=Railcraft:ore
         I:baseBlockMeta=8
         S:baseBlockTexture=railcraft:ore.poor.gold
         D:denseOreProbability=1
@@ -83,7 +83,7 @@ ores {
     }
 
     block_X {
-        S:baseBlock=Railcraft:tile.railcraft.ore
+        S:baseBlock=Railcraft:ore
         I:baseBlockMeta=9
         S:baseBlockTexture=railcraft:ore.poor.copper
         D:denseOreProbability=1
@@ -93,7 +93,7 @@ ores {
     }
 
     block_X {
-        S:baseBlock=Railcraft:tile.railcraft.ore
+        S:baseBlock=Railcraft:ore
         I:baseBlockMeta=10
         S:baseBlockTexture=railcraft:ore.poor.tin
         D:denseOreProbability=1
@@ -103,7 +103,7 @@ ores {
     }
 
     block_X {
-        S:baseBlock=Railcraft:tile.railcraft.ore
+        S:baseBlock=Railcraft:ore
         I:baseBlockMeta=11
         S:baseBlockTexture=railcraft:ore.poor.lead
         D:denseOreProbability=1


### PR DESCRIPTION
"S:baseBlock=Railcraft:tile.railcraft.ore" doesn't seem to work anymore.
"S:baseBlock=Railcraft:ore" does work however.

Railcraft version: 1.7.10-9.6.1.0
DenseOres version: 1.6.2
