### PR TITLE
Add simple configuration option to totally disable world generation.

### DIFF
--- a/src/main/java/com/rwtema/denseores/DenseOresConfig.java
+++ b/src/main/java/com/rwtema/denseores/DenseOresConfig.java
@@ -13,6 +13,9 @@ public class DenseOresConfig {
     public final static DenseOresConfig instance = new DenseOresConfig();
 
     public final static String CATEGORY_BLOCK = "ores.block_";
+    public final static String CATEGORY_WORLD_GENERATION = "world_generation";
+    
+    public final static Boolean WORLD_GENERATION_ENABLED;
 
     public void loadConfig(File file) {
 
@@ -77,6 +80,8 @@ public class DenseOresConfig {
                 } catch (NumberFormatException e) { // text after ore.block_ was
                     // not an integer
                 }
+            } else if (cat == CATEGORY_WORLD_GENERATION) {
+                this.WORLD_GENERATION_ENABLED = (config.get(cat, "enabled", true).getBoolean(true);
             }
         }
 

--- a/src/main/java/com/rwtema/denseores/DenseOresMod.java
+++ b/src/main/java/com/rwtema/denseores/DenseOresMod.java
@@ -36,9 +36,11 @@ public class DenseOresMod {
         DenseOresRegistry.buildOreDictionary();
         ModIntegration.addModIntegration();
 
-        WorldGenOres worldGen = new WorldGenOres();
-        GameRegistry.registerWorldGenerator(worldGen, 1000);
-        MinecraftForge.EVENT_BUS.register(worldGen);
+        if (DenseOresConfig.instance.WORLD_GENERATION_ENABLED) {
+            WorldGenOres worldGen = new WorldGenOres();
+            GameRegistry.registerWorldGenerator(worldGen, 1000);
+            MinecraftForge.EVENT_BUS.register(worldGen);
+        }
     }
 
     @EventHandler


### PR DESCRIPTION
This is useful in the case that you’re using another method to generate
ores (CoFH World Gen, for example) and want to control the
probabilities for dense ores on a more granular level.

I would like this implemented as a stopgap until probabilities are fully implemented as substitute for setting them all to 0. (I understand that development for 1.7 is mostly complete and that this is unlikely, hence my pull request.)